### PR TITLE
fix(dynamodb-global): cannot deploy global tables due to unresolved r…

### DIFF
--- a/packages/@aws-cdk/aws-dynamodb-global/test/integ.dynamodb.global.expected.json
+++ b/packages/@aws-cdk/aws-dynamodb-global/test/integ.dynamodb.global.expected.json
@@ -1,5 +1,7 @@
 [
   {
+  },
+  {
     "Resources": {
       "globdynamodbintegGlobalTableuseast162596384": {
         "Type": "AWS::DynamoDB::Table",

--- a/packages/@aws-cdk/aws-dynamodb-global/test/integ.dynamodb.global.ts
+++ b/packages/@aws-cdk/aws-dynamodb-global/test/integ.dynamodb.global.ts
@@ -1,10 +1,11 @@
 /// !cdk-integ *
 import { AttributeType } from '@aws-cdk/aws-dynamodb';
-import { App, RemovalPolicy } from '@aws-cdk/core';
+import { App, RemovalPolicy, Stack } from '@aws-cdk/core';
 import { GlobalTable } from '../lib';
 
 const app = new App();
-new GlobalTable(app, 'globdynamodbinteg', {
+const stack = new Stack(app, 'Default');
+new GlobalTable(stack, 'globdynamodbinteg', {
   partitionKey: { name: 'hashKey', type: AttributeType.STRING },
   tableName: 'integrationtest',
   regions: ["us-east-1", "us-east-2", "us-west-2"],


### PR DESCRIPTION
…esource dependencies

The DynamoDB global table construct was incorrectly declaring its dependencies,
having the coordinator stack depend on the resources in the table stacks,
instead of on the stacks themselves.
That resulted in resources in the coordinator stack depending on the global tables,
which cannot work, as those are from different stacks.
Changed the logic to declare dependencies between the stacks explicitly.

Fixes #4676



----

*By submitting this pull request, I confirm that my contribution is made under the terms of the Apache-2.0 license*

<!-- 
Please read the contribution guidelines and follow the pull-request checklist:
https://github.com/aws/aws-cdk/blob/master/CONTRIBUTING.md
 -->
